### PR TITLE
修改测试用例不依赖build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 docs/_book/
 docs/api/
 node_modules/
+test-reports/

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,16 @@ dist-clean: clean
 
 # Test Related
 
-test: build-dev
+test:
 	$(TEST) start --reporters mocha
 
-test-reports: build-dev
+test-watch:
+	$(TEST) start --reporters mocha --auto-watch --no-single-run
+
+test-reports:
 	$(TEST) start --reporters mocha,html,coverage
 
-test-reports-ci: build-dev
+test-reports-ci:
 	$(TEST) start --reporters mocha,html,coverage,coveralls
 
 # Doc Related

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     config.set({
 
         // base path that will be used to resolve all patterns (eg. files, exclude)
-        basePath: 'build/',
+        basePath: '',
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
         reporters: ['mocha'],
         htmlReporter: {
-            outputDir: 'build/test-reports/result'
+            outputDir: 'test-reports/result'
         },
         coverageReporter: {
             reporters: [

--- a/src/doc.js
+++ b/src/doc.js
@@ -5,6 +5,8 @@
 
 define(function () {
 
+    console.log('doc')
+
     function docFactory(mainDoc) {
         var doc = mainDoc.querySelector('#sfr-app');
         if (!doc) {

--- a/src/doc.js
+++ b/src/doc.js
@@ -5,8 +5,6 @@
 
 define(function () {
 
-    console.log('doc')
-
     function docFactory(mainDoc) {
         var doc = mainDoc.querySelector('#sfr-app');
         if (!doc) {

--- a/src/resource.js
+++ b/src/resource.js
@@ -3,7 +3,9 @@
  * @author harttle<yangjun14@baidu.com>
  * @module resource
  */
-define(['utils/http', 'lang/underscore'], function (http, _) {
+define(function (require) {
+    var http = require('utils/http');
+    var _ = require('lang/underscore');
 
     /**
      * The REST resource CRUD utility

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -8,7 +8,7 @@ define(function (require) {
     var extend = require('../lang/underscore').extend;
     var globalConfig = require('./router/config');
     var controller = require('./router/controller');
-    var _ = require('../lang/underscore.js');
+    var _ = require('../lang/underscore');
 
     function routerFactory(logger) {
         /**

--- a/src/utils/di.js
+++ b/src/utils/di.js
@@ -7,7 +7,7 @@
  */
 define(function (require) {
     var assert = require('../lang/assert');
-    var _ = require('../lang/underscore.js');
+    var _ = require('../lang/underscore');
 
     /**
      * Create a IoC container

--- a/test-main.js
+++ b/test-main.js
@@ -9,7 +9,7 @@ var TEST_FILES = Object.keys(window.__karma__.files).filter(isTestFile);
 require.config({
     baseUrl: '/base/src',
     paths: {
-        test: '../test'
+        test: '/base/test'
     }
 });
 
@@ -25,17 +25,6 @@ require(mods, function(){
     console.log(mods.length + ' test modules loaded');
     window.__karma__.start();
 });
-
-
-// 工具函数
-function pathMap(arr) {
-    var map = {};
-    arr.forEach(function(file){
-        var mod = getModuleId(file);
-        map[mod] = file.slice(0, -3);
-    });
-    return map;
-}
 
 function isTestFile(filepath){
     return /\/base\/test\//.test(filepath);

--- a/test-main.js
+++ b/test-main.js
@@ -6,10 +6,11 @@
 var TEST_FILES = Object.keys(window.__karma__.files).filter(isTestFile);
 
 // 依赖配置
-var paths = pathMap(TEST_FILES);
 require.config({
     baseUrl: '/base/src',
-    paths: paths
+    paths: {
+        test: '../test'
+    }
 });
 
 // 启动测试

--- a/test/action.js
+++ b/test/action.js
@@ -10,10 +10,10 @@
 /* globals sinon: true */
 
 define(function (require) {
-    var Promise = require('../src/lang/promise.js');
-    var actionFactory = require('../src/action');
-    var logger = require('../src/utils/logger');
-    var Emitter = require('../src/utils/emitter');
+    var Promise = require('lang/promise');
+    var actionFactory = require('action');
+    var logger = require('utils/logger');
+    var Emitter = require('utils/emitter');
 
     describe('action', function () {
         var action;

--- a/test/doc.js
+++ b/test/doc.js
@@ -7,7 +7,11 @@
 
 /* globals sinon: true */
 
-require(['../src/doc'], function (docFactory) {
+define(function (require) {
+    var docFactory = require('doc');
+
+    console.log('ok');
+
     describe('doc', function () {
         beforeEach(function () {
             var els = document.querySelectorAll('#sfr-app');

--- a/test/doc.js
+++ b/test/doc.js
@@ -10,8 +10,6 @@
 define(function (require) {
     var docFactory = require('doc');
 
-    console.log('ok');
-
     describe('doc', function () {
         beforeEach(function () {
             var els = document.querySelectorAll('#sfr-app');

--- a/test/lang/map.js
+++ b/test/lang/map.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/lang/map'], function (Map) {
+define(['lang/map'], function (Map) {
     describe('Map', function () {
         var map;
         beforeEach(function () {

--- a/test/lang/promise.js
+++ b/test/lang/promise.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/lang/promise'], function (Promise) {
+define(['lang/promise'], function (Promise) {
     describe('Promise', function () {
         this.timeout(5000);
 

--- a/test/lang/underscore.js
+++ b/test/lang/underscore.js
@@ -8,7 +8,7 @@
 /* globals sinon: true */
 
 define(function (require) {
-    var _ = require('src/lang/underscore');
+    var _ = require('lang/underscore');
 
     describe('underscore', function () {
         var obj = {

--- a/test/resource.js
+++ b/test/resource.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/resource'], function (Resource) {
+define(['resource'], function (Resource) {
     describe('resource', function () {
         this.timeout(5000);
         var xhr;

--- a/test/utils/cache.js
+++ b/test/utils/cache.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/utils/cache'], function (cache) {
+define(['utils/cache'], function (cache) {
     describe('view/cache', function () {
         beforeEach(function () {
             cache.clear();

--- a/test/utils/di.js
+++ b/test/utils/di.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/utils/di'], function (DI) {
+define(['utils/di'], function (DI) {
     describe('di', function () {
         var di;
         var require;

--- a/test/utils/dom.js
+++ b/test/utils/dom.js
@@ -6,7 +6,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
-define(['../src/utils/dom'], function (dom) {
+define(['utils/dom'], function (dom) {
     describe('utils/dom', function () {
         describe('.hasClass()', function () {
             it('should return false when className empty', function () {

--- a/test/utils/http.js
+++ b/test/utils/http.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/utils/http'], function (http) {
+define(['utils/http'], function (http) {
     describe('http', function () {
         this.timeout(5000);
 

--- a/test/utils/url.js
+++ b/test/utils/url.js
@@ -9,7 +9,7 @@
 
 /* globals sinon: true */
 
-define(['../src/utils/url'], function (url) {
+define(['utils/url'], function (url) {
     describe('utils/url', function () {
 
         describe('.param()', function () {


### PR DESCRIPTION
修改后可以直接跑源码的测试, 不依赖`build`命令, 可以方便的`watch`了, 主要修改如下:

1. `test/*`目录内文件引用时直接基于`baseUrl`引用, 不使用相对路径(不然会找不到测试文件依赖的模块)
1. `require()`模块时不添加`ext`扩展名
1. 尽量使用显式`require`引用依赖, 不直接使用`deps`定义, 参考了: <http://efe.baidu.com/blog/dissecting-amd-how/>
1. 添加了`npm run test-watch`命令, 不过发现修改单个也会全量测试.
1. 把测试覆盖率结果、测试用例html结果生成到了`test-reports/`下了
1. 运行了`npm run dist`没有影响

具体的还请 @harttle 多rere~

✌️ 