### PR TITLE
修复错字 should

### DIFF
--- a/test/router/router/url.spec.js
+++ b/test/router/router/url.spec.js
@@ -144,7 +144,7 @@ define(function (require) {
 
         describe('#equal()', function () {
 
-            it('shoud return boolean', function () {
+            it('should return boolean', function () {
                 var url1 = new URL('../work/search?kw=xxx&t=10');
                 var url2 = new URL('../work/search');
 
@@ -171,7 +171,7 @@ define(function (require) {
         });
 
         describe('#equalWithFragment()', function () {
-            it('shoud return boolean', function () {
+            it('should return boolean', function () {
                 var url1 = new URL('../work/search?kw=xxx&t=10');
                 var url2 = new URL('../work/search?kw=xxx&t=10#www');
                 var url3 = new URL('../work/search?kw=xxx&t=10#www');


### PR DESCRIPTION
偶然发现测试用例里有2个单词和其她的不一样，应该是错别字，并且发现本地测试时直接运行 `npm run test` 会失败，需要先按装个 `apmjs` ，如：

<https://github.com/Ralltiir/ralltiir/blob/0623786e652e2bc5ac23ac0c9294afca3092401b/.travis.yml#L16-L17>

用在文档体现下？