### PR TITLE
block action error throw

### DIFF
--- a/amd-lock.json
+++ b/amd-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ralltiir",
-  "version": "2.13.6",
+  "version": "2.13.9",
   "dependencies": {
     "@searchfe/assert": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralltiir",
-  "version": "2.13.9",
+  "version": "2.13.10",
   "discription": "前端极速浏览框架，目标是提升用户体验，提供沉浸式浏览方式。",
   "scripts": {
     "doc:install": "gitbook install ./docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralltiir",
-  "version": "2.13.9",
+  "version": "2.13.10-1",
   "discription": "前端极速浏览框架，目标是提升用户体验，提供沉浸式浏览方式。",
   "scripts": {
     "doc:install": "gitbook install ./docs",

--- a/src/action.js
+++ b/src/action.js
@@ -265,7 +265,7 @@ define(function (require) {
                 e.url = URL.resolve(config.root, url);
                 location.replace(e.url);
                 exports.emit('redirectFailed', e);
-                throw e;
+                // throw e;
             }
         };
 

--- a/src/action.js
+++ b/src/action.js
@@ -263,6 +263,9 @@ define(function (require) {
             }
             catch (e) {
                 e.url = URL.resolve(config.root, url);
+
+                location.replace(e.url);
+
                 exports.emit('redirectFailed', e);
                 // throw e;
             }

--- a/src/action.js
+++ b/src/action.js
@@ -263,9 +263,13 @@ define(function (require) {
             }
             catch (e) {
                 e.url = URL.resolve(config.root, url);
-                location.replace(e.url);
+
+                setTimeout(function () {
+                    location.replace(e.url);
+                }, 0);
+
                 exports.emit('redirectFailed', e);
-                throw e;
+                // throw e;
             }
         };
 

--- a/test/action.js
+++ b/test/action.js
@@ -382,7 +382,6 @@ define(function (require) {
                 function fn() {
                     action.redirect('/not-defined-service', {}, {});
                 }
-                expect(fn).to.throw(/service not found/);
                 try {
                     fn();
                 }


### PR DESCRIPTION
acton 的失败本身内部有兼容处理，不需要往外抛。
